### PR TITLE
Output "empty" groups to preserve hierarchy.

### DIFF
--- a/io_scene_ac3d/export_ac3d.py
+++ b/io_scene_ac3d/export_ac3d.py
@@ -165,8 +165,8 @@ class ExportAC3D:
 								if len(c.children):
 									self.parseLevel(p, c.children, ignore_select, local_transform)
 					continue
-#				elif ob.type == 'EMPTY':
-#					ac_ob = AC3D.Group(ob.name, ob, self.export_conf, local_transform)
+				elif ob.type == 'EMPTY':
+					ac_ob = AC3D.Group(ob.name, ob, self.export_conf, local_transform)
 				else:
 					TRACE('Skipping object {0} (type={1})'.format(ob.name, ob.type))
 


### PR DESCRIPTION
Hello,

A while ago EMPTY groups were commented out.  This however breaks some valid hierarchies.  For instance see [this model](https://github.com/yuriknsk/tu154b/blob/master/Model/exterior.ac) (press View Raw to download - ~5MB): when you import it into Blender for the first time there's a certain short top-level hierarchy, but after the export and import back all "empty" nodes (having children and nothing else) are "flattened".

The patch seem to work but I don't grok Blender or AC3D so I can't tell for sure if the change is complete and correct.

Thanks in advance for considering the patch!
