### PR TITLE
Do not output zero location which is no-op since it is relative.

### DIFF
--- a/io_scene_ac3d/AC3D.py
+++ b/io_scene_ac3d/AC3D.py
@@ -87,7 +87,8 @@ class Object:
 			pos_rel = self.pos_abs - self.parent.matrix_world.to_translation()
 
 			location = self.export_config.global_matrix * pos_rel
-			strm.write('loc {0:.7f} {1:.7f} {2:.7f}\n'.format(location[0], location[1], location[2]))
+			if [coord for coord in location if coord != 0.0]:
+				strm.write('loc {0:.7f} {1:.7f} {2:.7f}\n'.format(location[0], location[1], location[2]))
 
 		self._write(strm)
 		strm.write('kids {0}\n'.format(len(self.children)))


### PR DESCRIPTION
Export produces lots of "loc 0.0000000 0.0000000 0.0000000" which are no-op anyway, so the patch suppresses them.  I had only little experience with Python so I'm not sure if the construct in "if" is the best way to check for presence of at least one non-zero value.

Thanks!
