### PR TITLE
Export: Support for crease angle

### DIFF
--- a/README
+++ b/README
@@ -29,9 +29,6 @@ Known Issues:
    * There's an option "Export Render Layer" - ie, only export what's currently
      visible - this doesn't work, but is in the plan
 
- - Importer:
-   * No ngons yet.
-
 Things to come:
 	- I want to have an option to overwrite, or to prompt the operator if they want to overwrite textures on an export
 

--- a/README
+++ b/README
@@ -3,8 +3,8 @@ README for Blender-AC3D
 What is it?
 It's a few python scripts to import/export AC3D data into and out of Blender 2.63+. For earlier Blender 2.6x versions you need an older revision of the plugin (https://github.com/majic79/Blender-AC3D/tree/BL2.62)
 
-Why blender 2.6?
-Because in the migration from 2.4X to 2.5, it lost AC3D support. This mod aims to bring that back to 2.6
+Why blender 2.6/2.7?
+Because in the migration from 2.4X to 2.5, it lost AC3D support. This mod aims to bring that back to 2.6 and 2.7
 
 So it had it before?
 Yes, this is mainly a port of those files to enable the import/export of .ac files in blender 2.5

--- a/io_scene_ac3d/AC3D.py
+++ b/io_scene_ac3d/AC3D.py
@@ -242,6 +242,8 @@ class Poly (Object):
 		
 	def _write( self, strm ):
 
+		strm.write('crease {0}\n'.format(self.crease))		
+
 		if len(self.tex_name) > 0:
 			strm.write('texture "{0}"\n'.format(self.tex_name))
 			strm.write('texrep {0} {1}\n'.format(self.tex_rep[0], self.tex_rep[1]))

--- a/io_scene_ac3d/AC3D.py
+++ b/io_scene_ac3d/AC3D.py
@@ -366,7 +366,7 @@ class Material:
 			else:
 				self.emis = [bl_mat.emit, bl_mat.emit, bl_mat.emit]
 			self.spec = bl_mat.specular_intensity * bl_mat.specular_color
-			self.shi = bl_mat.specular_hardness
+			self.shi = int(bl_mat.specular_hardness * (128/511))
 			if bl_mat.use_transparency:
 				self.trans = 1.0 - bl_mat.alpha
 			else:

--- a/io_scene_ac3d/__init__.py
+++ b/io_scene_ac3d/__init__.py
@@ -238,7 +238,7 @@ class ExportAC3D(bpy.types.Operator, ExportHelper):
 	crease_angle = FloatProperty(
 							name="Default Crease Angle",
 							description="Default crease angle for exported .ac faces",
-							default=radians(179.0),
+							default=radians(35.0),
 							options={"ANIMATABLE"},
 							unit="ROTATION",
 							subtype="ANGLE",

--- a/io_scene_ac3d/export_ac3d.py
+++ b/io_scene_ac3d/export_ac3d.py
@@ -85,7 +85,7 @@ class ExportAC3D:
 			global_coords=False,
 			mircol_as_emis=True,
 			mircol_as_amb=False,
-			crease_angle=radians(179.0),
+			crease_angle=radians(35.0),
 			):
 
 			self.export_conf = ExportConf(

--- a/io_scene_ac3d/export_ac3d.py
+++ b/io_scene_ac3d/export_ac3d.py
@@ -165,8 +165,8 @@ class ExportAC3D:
 								if len(c.children):
 									self.parseLevel(p, c.children, ignore_select, local_transform)
 					continue
-#				elif ob.type == 'EMPTY':
-#					ac_ob = AC3D.Group(ob.name, ob, self.export_conf, local_transform)
+				elif ob.type == 'EMPTY':
+					ac_ob = AC3D.Group(ob.name, ob, self.export_conf, local_transform)
 				else:
 					TRACE('Skipping object {0} (type={1})'.format(ob.name, ob.type))
 

--- a/io_scene_ac3d/import_ac3d.py
+++ b/io_scene_ac3d/import_ac3d.py
@@ -77,7 +77,8 @@ class AcMat:
 		bl_mat.ambient = (self.amb[0] + self.amb[1] + self.amb[2]) / 3.0
 		bl_mat.emit = (self.emis[0] + self.emis[1] + self.emis[2]) / 3.0
 		bl_mat.specular_color = self.spec
-		bl_mat.specular_intensity = float(self.shi) / 100
+		bl_mat.specular_intensity = 1.0
+		bl_mat.specular_hardness = int(float(self.shi) * 511.0/128.0)
 		bl_mat.alpha = 1.0 - self.trans
 		if bl_mat.alpha < 1.0:
 			bl_mat.use_transparency = self.import_config.use_transparency

--- a/io_scene_ac3d/import_ac3d.py
+++ b/io_scene_ac3d/import_ac3d.py
@@ -73,6 +73,7 @@ class AcMat:
 		self.import_config = import_config
 
 	def make_blender_mat(self, bl_mat):
+		bl_mat.specular_shader = 'PHONG'
 		bl_mat.diffuse_color = self.rgb
 		bl_mat.ambient = (self.amb[0] + self.amb[1] + self.amb[2]) / 3.0
 		bl_mat.emit = (self.emis[0] + self.emis[1] + self.emis[2]) / 3.0

--- a/io_scene_ac3d/import_ac3d.py
+++ b/io_scene_ac3d/import_ac3d.py
@@ -115,7 +115,7 @@ class AcMat:
 				tex_slot.alpha_factor = 1.0
 				tex_slot.use_map_alpha = True
 				tex_slot.use = True
-				tex_slot.uv_layer = tex_name
+				tex_slot.uv_layer = 'UVMap'
 				self.bmat_keys[tex_name] = bl_mat
 		return bl_mat
 


### PR DESCRIPTION
With this commit crease angle is now also supported when exporting, not only when importing.
Shininess is now handled properly. It is now mapped to hardness (1-511 [Blender] from 0-128 [AC3D]).
Also imported materials will be Phong per default now, which matches Flightgears fixed pipeline shader.
Also fixed a major bug that made imported UV map not set properly to texture.
The importer now supports ngons.