### PR TITLE
Various improvements

### DIFF
--- a/README
+++ b/README
@@ -21,13 +21,7 @@ Go to File->Import->AC3D (.ac), select a file and let it do the work
 Known Issues:
 
  - Exporter:
-   * Export packed .blend images is untested...
-   * It will either export everything, or everything that's selected. Default
-     behaviour is to export everything, if you want to only export those items
-     that you can see (ie, in the render scene), then select all those items and
-     check the "Selection Only" option on the export dialog.
-   * There's an option "Export Render Layer" - ie, only export what's currently
-     visible - this doesn't work, but is in the plan
+   * Export packed .blend images will make the exporter fail
 
 Things to come:
 	- I want to have an option to overwrite, or to prompt the operator if they want to overwrite textures on an export

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-README for Blender-AC3D
+README for Blender-AC3D - Version 2.00
 
 What is it?
 It's a few python scripts to import/export AC3D data into and out of Blender 2.63+. For earlier Blender 2.6x versions you need an older revision of the plugin (https://github.com/majic79/Blender-AC3D/tree/BL2.62)

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-README for Blender-AC3D - Version 2.00
+README for Blender-AC3D - Version 2.01
 
 What is it?
 It's a few python scripts to import/export AC3D data into and out of Blender 2.63+. For earlier Blender 2.6x versions you need an older revision of the plugin (https://github.com/majic79/Blender-AC3D/tree/BL2.62)

--- a/io_scene_ac3d/AC3D.py
+++ b/io_scene_ac3d/AC3D.py
@@ -241,8 +241,15 @@ class Poly (Object):
 			else:
 				uv_coords = None
 
-			surf = self.Surface(self.export_config, bl_face, self.ac_mats, mesh.show_double_sided, is_flipped, uv_coords)
+			surf = self.Surface(self.export_config, bl_face, self.ac_mats, mesh.show_double_sided, is_flipped, uv_coords, 0)
 			self.surfaces.append(surf)
+
+		for edge_idx in range(len(mesh.edges)):
+			bl_edge = mesh.edges[edge_idx]
+			
+			edge = self.Surface(self.export_config, bl_edge, self.ac_mats, mesh.show_double_sided, is_flipped, None, 2)
+			self.surfaces.append(edge)
+
 		
 	def _write( self, strm ):
 
@@ -272,14 +279,15 @@ class Poly (Object):
 									ac_mats,
 									is_two_sided,
 									is_flipped,
-									uv_coords ):
+									uv_coords,
+									surf_type ):
 			self.export_config = export_config
 			self.mat = 0		# material index for this surface
 			self.bl_face = bl_face
 			self.uv_coords = uv_coords
 			self.is_two_sided = is_two_sided
 			self.is_flipped = is_flipped
-			self.ac_surf_flags = self.SurfaceFlags(0, False, True)
+			self.ac_surf_flags = self.SurfaceFlags(surf_type, False, True)
 
 			self.parse_blender_face(bl_face, ac_mats)
 
@@ -305,11 +313,19 @@ class Poly (Object):
 
 		def parse_blender_face(self, bl_face, ac_mats):
 
-			if bl_face.material_index in ac_mats:
-				self.mat = ac_mats[bl_face.material_index]
-	
-			self.ac_surf_flags.smooth_shaded = bl_face.use_smooth
-			self.ac_surf_flags.twosided = self.is_two_sided
+			try:
+				if bl_face.material_index in ac_mats:
+					self.mat = ac_mats[bl_face.material_index]
+			except:
+				#is edge
+				self.mat = 0
+			try:
+				self.ac_surf_flags.smooth_shaded = bl_face.use_smooth
+				self.ac_surf_flags.twosided = self.is_two_sided
+			except:
+				#is edge
+				self.ac_surf_flags.smooth_shaded = True
+				self.ac_surf_flags.twosided = True
 		
 		class SurfaceFlags:
 			def __init__( self,

--- a/io_scene_ac3d/AC3D.py
+++ b/io_scene_ac3d/AC3D.py
@@ -394,13 +394,24 @@ class Material:
 		if bl_mat:
 			self.name = bl_mat.name
 			self.rgb = bl_mat.diffuse_color
-			self.amb = [bl_mat.ambient, bl_mat.ambient, bl_mat.ambient]
+			if export_config.mircol_as_amb:
+				self.amb = bl_mat.mirror_color
+			else:
+				self.amb = [bl_mat.ambient, bl_mat.ambient, bl_mat.ambient]
 			if export_config.mircol_as_emis:
-				self.emis = bl_mat.mirror_color * bl_mat.emit
+				self.emis = bl_mat.mirror_color# * bl_mat.emit   confusing if enabled, should be either mirror color or greyscale emissive
 			else:
 				self.emis = [bl_mat.emit, bl_mat.emit, bl_mat.emit]
-			self.spec = bl_mat.specular_intensity * bl_mat.specular_color
-			self.shi = int(bl_mat.specular_hardness * (128/511))
+			self.spec = bl_mat.specular_intensity * bl_mat.specular_color   
+
+			acMin = 0.0
+			acMax = 128.0
+			blMin = 1.0
+			blMax = 511.0
+			acRange = (acMax - acMin)  
+			blRange = (blMax - blMin)  
+			self.shi = int(round((((float(bl_mat.specular_hardness) - blMin) * acRange) / blRange) + acMin, 0))
+
 			if bl_mat.use_transparency:
 				self.trans = 1.0 - bl_mat.alpha
 			else:

--- a/io_scene_ac3d/AC3D.py
+++ b/io_scene_ac3d/AC3D.py
@@ -151,7 +151,7 @@ class Poly (Object):
 			if mesh.use_auto_smooth:
 				self.crease = degrees(mesh.auto_smooth_angle)
 			else:
-				self.crease = self.export_config.crease_angle
+				self.crease = degrees(self.export_config.crease_angle)
 
 		#bpy.data.meshes.remove(mesh)
 		

--- a/io_scene_ac3d/AC3D.py
+++ b/io_scene_ac3d/AC3D.py
@@ -200,6 +200,10 @@ class Poly (Object):
 							# TRACE('File already exists "{0}"- not overwriting!'.format(tex_name))
 						
 						self.tex_name = tex_name
+						try:
+							self.tex_rep = [tex_slot.texture.repeat_x, tex_slot.texture.repeat_y]
+						except:
+							print("Failed to export texrep")
 						break
 
 			# Blender to AC3d index cross-reference

--- a/io_scene_ac3d/AC3D.py
+++ b/io_scene_ac3d/AC3D.py
@@ -144,14 +144,14 @@ class Poly (Object):
 
 		for mod in self.bl_obj.modifiers:
 			if mod.type=='EDGE_SPLIT':
-				self.crease = degrees(mod.split_angle)
+				self.crease = round(degrees(mod.split_angle), 3)
 				break
 
 		if not self.crease:
 			if mesh.use_auto_smooth:
-				self.crease = degrees(mesh.auto_smooth_angle)
+				self.crease = round(degrees(mesh.auto_smooth_angle), 3)
 			else:
-				self.crease = degrees(self.export_config.crease_angle)
+				self.crease = round(degrees(self.export_config.crease_angle), 3)
 
 		#bpy.data.meshes.remove(mesh)
 		

--- a/io_scene_ac3d/__init__.py
+++ b/io_scene_ac3d/__init__.py
@@ -215,16 +215,16 @@ class ExportAC3D(bpy.types.Operator, ExportHelper):
 							description="Export selected objects only",
 							default=False,
 							)
-	skip_data = BoolProperty(
-							name="Skip Data",
-							description="don't export mesh names as data fields",
-							default=False,
-							)
-	global_coords = BoolProperty(
-							name="Global Co-ordinates",
-							description="Transform all vertices of all meshes to global coordinates",
-							default=False,
-							)
+#	skip_data = BoolProperty(
+#							name="Skip Data",
+#							description="don't export mesh names as data fields",
+#							default=False,
+#							)
+#	global_coords = BoolProperty(
+#							name="Global Co-ordinates",
+#							description="Transform all vertices of all meshes to global coordinates",
+#							default=False,
+#							)
 	mircol_as_emis = BoolProperty(
 							name="Mirror col as Emis",
 							description="export mirror colour as emissive colour",

--- a/io_scene_ac3d/import_ac3d.py
+++ b/io_scene_ac3d/import_ac3d.py
@@ -189,7 +189,7 @@ class AcObj:
 		self.location = [0,0,0]			# translation location of the center relative to the parent object
 		self.rotation = mathutils.Matrix(([1,0,0],[0,1,0],[0,0,1]))	# 3x3 rotational matrix for vertices
 		self.url = ''				# url of the object (??!)
-		self.crease = 30			# crease angle for smoothing
+		self.crease = 61			# crease angle for smoothing
 		self.vert_list = []				# list of Vector(X,Y,Z) objects
 		self.surf_list = []			# list of attached surfaces
 		self.face_list = []			# flattened surface list

--- a/io_scene_ac3d/import_ac3d.py
+++ b/io_scene_ac3d/import_ac3d.py
@@ -240,13 +240,11 @@ class AcObj:
 			line = line.strip().split()
 			if line[0] == 'SURF':
 				surf = AcSurf(line[1], ac_file, self.import_config)
-				if( len(surf.refs) in [3,4] ):
+				if( surf.flags.type != 0 or len(surf.refs) in [3,4] ):
 					self.surf_list.append(surf)
 				else:
 					if(len(surf.refs) > 4):
-						print(surf.refs)
 						tess = ngon_tessellate(self.vert_list, surf.refs)
-						print(tess)
 						for triangle in tess:
 							new_triangle = []
 							for tri_index in triangle:
@@ -411,6 +409,16 @@ class AcObj:
 			# For that reason I let all faces that reference the first vertex reference the last copy, so that I can cleanly remove the first afterwards.
 			me.vertices.add(1)
 			me.vertices[len(self.vert_list)].co = self.vert_list[0]
+
+			#edges
+			me.edges.add(len(self.edge_list))
+			for i in range(len(self.edge_list)):
+				if(self.edge_list[i][0] == 0):
+					self.edge_list[i][0] = len(self.vert_list)
+				if(self.edge_list[i][1] == 0):
+					self.edge_list[i][1] = len(self.vert_list)
+				NewEdge = (self.edge_list[i][0], self.edge_list[i][1])
+				me.edges[i].vertices = NewEdge
 
 			for i in range(len(self.face_list)):
 				if(self.face_list[i][0] == 0):
@@ -635,11 +643,11 @@ class AcSurf:
 		if self.flags.type != 0:
 			# poly-line
 			for x in range(len(self.refs)-1):
-				surf_edges.append([self.refs[x],self.refs[x+1]])
+				surf_edges.append([self.refs[x], self.refs[x+1]])
 
 			if self.flags.type == 1:
 				# closed poly-line
-				surf_edges.append([self.refs[len(self.refs)-1],self.refs[0]])
+				surf_edges.append([self.refs[len(self.refs)-1], self.refs[0]])
 		return surf_edges
 
 class ImportConf:

--- a/io_scene_ac3d/import_ac3d.py
+++ b/io_scene_ac3d/import_ac3d.py
@@ -77,10 +77,22 @@ class AcMat:
 		bl_mat.specular_shader = 'PHONG'
 		bl_mat.diffuse_color = self.rgb
 		bl_mat.ambient = (self.amb[0] + self.amb[1] + self.amb[2]) / 3.0
+		if self.import_config.use_amb_as_mircol:
+				bl_mat.mirror_color = self.amb
 		bl_mat.emit = (self.emis[0] + self.emis[1] + self.emis[2]) / 3.0
+		if self.import_config.use_emis_as_mircol:
+				bl_mat.mirror_color = self.emis
 		bl_mat.specular_color = self.spec
 		bl_mat.specular_intensity = 1.0
-		bl_mat.specular_hardness = int(float(self.shi) * 511.0/128.0)
+
+		acMin = 0.0
+		acMax = 128.0
+		blMin = 1.0
+		blMax = 511.0
+		acRange = (acMax - acMin)  
+		blRange = (blMax - blMin)  
+		bl_mat.specular_hardness = int(round((((float(self.shi) - acMin) * blRange) / acRange) + blMin, 0))
+
 		bl_mat.alpha = 1.0 - self.trans
 		if bl_mat.alpha < 1.0:
 			bl_mat.use_transparency = self.import_config.use_transparency

--- a/io_scene_ac3d/import_ac3d.py
+++ b/io_scene_ac3d/import_ac3d.py
@@ -333,7 +333,7 @@ class AcObj:
 			self.bl_obj = bpy.data.objects.new(self.name, None)
 
 		if self.type == 'poly':
-			meshname = self.name
+			meshname = self.name+".mesh"
 			if len(self.data)>0:
 				meshname = self.data
 			me = bpy.data.meshes.new(meshname)


### PR DESCRIPTION
Fixed that when exporting crease angle would be output in radians.
Texture repetition is now supported.
Import now supports lines.
Imported meshes will now have distinct name from its object.
Import and export will no longer tessellate the ngons into triangles and quads.
Import will now import UV map even if no texture is attached.
Importing floating points texreps will no longer crash the script.
Removed options from the exporter that is not functional.
Updated readme file, and added a version number.
Exported crease angles are now rounded to 3rd decimal place.
